### PR TITLE
Add Flask-based PWA with Supabase logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# web_app_mh
+# Minimal PWA Flask App
+
+A tiny Progressive Web App with a Flask backend and Supabase logging. Users enter a custom ID, view static content, and visits are recorded.
+
+## Quick Start
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+# create .env with SUPABASE_URL and SUPABASE_API_KEY
+python api/index.py
+```
+
+## Supabase Setup
+
+Run the SQL schema in your project:
+
+```bash
+psql "$SUPABASE_DB" < sql/schema.sql
+```
+
+## Environment Variables
+
+For local dev and Vercel deployment set:
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY` (server side only)
+
+## Deploying to Vercel
+
+1. Push this repo to GitHub.
+2. In Vercel, import the project.
+3. Add the environment variables above.
+4. Deploy.
+
+## PWA Install
+
+Open the site on Android Chrome or iOS Safari and use “Add to Home Screen.” The app works offline and launches without browser chrome.
+
+## Privacy
+
+The app stores the typed ID and visit timestamps in Supabase. No other personal data is collected.

--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,105 @@
+import os
+from datetime import datetime, timezone
+from flask import Flask, request, jsonify, render_template, redirect, make_response
+from supabase import create_client, Client
+
+# Load environment variables
+SUPABASE_URL = os.environ.get("SUPABASE_URL")
+SUPABASE_KEY = os.environ.get("SUPABASE_API_KEY") or os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+
+supabase: Client | None = None
+if SUPABASE_URL and SUPABASE_KEY:
+    supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+
+# Flask app pointing to parent template and static folders
+app = Flask(__name__, template_folder="../templates", static_folder="../static")
+
+@app.get("/")
+def login_page():
+    return render_template("login.html")
+
+@app.get("/content")
+def content_page():
+    user_id = request.cookies.get("user_id")
+    if not user_id:
+        return redirect("/")
+    return render_template("content.html", user_id=user_id)
+
+@app.post("/api/login")
+def api_login():
+    data = request.get_json()
+    if not data or "user_id" not in data:
+        return jsonify({"error": "user_id required"}), 400
+    user_id = data["user_id"].strip()
+    if not user_id:
+        return jsonify({"error": "invalid user_id"}), 400
+
+    # Upsert user
+    supabase.table("app_user").upsert({"user_id": user_id}).execute()
+    # Insert first login if missing
+    existing = supabase.table("session_login").select("id").eq("user_id", user_id).execute()
+    if not existing.data:
+        supabase.table("session_login").insert({"user_id": user_id}).execute()
+
+    resp = make_response(jsonify({"ok": True}))
+    resp.set_cookie("user_id", user_id, httponly=True, samesite="Lax", secure=True)
+    return resp
+
+@app.post("/api/visit-start")
+def visit_start():
+    data = request.get_json()
+    if not data or "user_id" not in data:
+        return jsonify({"error": "user_id required"}), 400
+    user_id = data["user_id"].strip()
+    if not user_id:
+        return jsonify({"error": "invalid user_id"}), 400
+
+    res = supabase.table("visit").insert({"user_id": user_id}).execute()
+    visit_id = res.data[0]["id"] if res.data else None
+    return jsonify({"visit_id": visit_id})
+
+@app.post("/api/visit-end")
+def visit_end():
+    data = request.get_json(silent=True)
+    if not data:
+        data = request.form.to_dict()
+
+    user_id = (data.get("user_id") or "").strip()
+    if not user_id:
+        return jsonify({"error": "invalid user_id"}), 400
+
+    visit_id = data.get("visit_id")
+    started_at = data.get("started_at")
+
+    now = datetime.now(timezone.utc)
+    duration = None
+    started_dt = None
+    if started_at:
+        try:
+            started_dt = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+            duration = int((now - started_dt).total_seconds())
+        except ValueError:
+            started_dt = None
+
+    if visit_id:
+        supabase.table("visit").update({
+            "ended_at": now.isoformat(),
+            "duration_seconds": duration
+        }).eq("id", visit_id).execute()
+    else:
+        supabase.table("visit").insert({
+            "user_id": user_id,
+            "started_at": started_dt.isoformat() if started_dt else now.isoformat(),
+            "ended_at": now.isoformat(),
+            "duration_seconds": duration
+        }).execute()
+
+    return jsonify({"ok": True})
+
+# Vercel entry point
+
+def handler(request, *args, **kwargs):
+    return app(request, *args, **kwargs)
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask==3.0.3
+supabase==2.6.0
+python-dotenv==1.0.1

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,20 @@
+create table if not exists app_user (
+  user_id text primary key,
+  created_at timestamptz default now()
+);
+
+create table if not exists session_login (
+  id bigserial primary key,
+  user_id text references app_user(user_id) on delete cascade,
+  first_login_at timestamptz not null default now()
+);
+
+create table if not exists visit (
+  id bigserial primary key,
+  user_id text references app_user(user_id) on delete cascade,
+  started_at timestamptz not null default now(),
+  ended_at timestamptz,
+  duration_seconds integer
+);
+
+create index if not exists visit_user_started_idx on visit (user_id, started_at);

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "Minimal PWA",
+  "short_name": "PWA",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff"
+}

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -1,0 +1,22 @@
+const CACHE_NAME = 'pwa-cache-v1';
+const URLS_TO_CACHE = ['/', '/content', '/static/manifest.json'];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+    ))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});

--- a/templates/content.html
+++ b/templates/content.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Content</title>
+<link rel="manifest" href="/static/manifest.json">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<style>
+body{font-family:system-ui,sans-serif;margin:0;background:#f9f9f9;display:flex;align-items:center;justify-content:center;height:100vh;}
+.card{max-width:400px;width:100%;padding:1rem;}
+</style>
+</head>
+<body>
+<div class="card">
+<p>User: {{ user_id }}</p>
+<p>Welcome!</p>
+</div>
+<script>
+const userId = localStorage.getItem('user_id');
+if (!userId) {
+  window.location.href = '/';
+}
+let visitId = null;
+let startedAt = new Date().toISOString();
+// Start visit
+fetch('/api/visit-start', {
+  method: 'POST',
+  headers: {'Content-Type': 'application/json'},
+  body: JSON.stringify({ user_id: userId })
+}).then(r => r.json()).then(d => { visitId = d.visit_id; });
+
+function endVisit() {
+  if (!startedAt) return;
+  if (navigator.sendBeacon) {
+    const data = new FormData();
+    data.append('user_id', userId);
+    if (visitId) data.append('visit_id', visitId);
+    data.append('started_at', startedAt);
+    navigator.sendBeacon('/api/visit-end', data);
+  } else {
+    fetch('/api/visit-end', {
+      method: 'POST',
+      headers: {'Content-Type':'application/json'},
+      body: JSON.stringify({ user_id: userId, visit_id: visitId, started_at: startedAt })
+    });
+  }
+}
+document.addEventListener('visibilitychange', () => { if (document.hidden) endVisit(); });
+window.addEventListener('pagehide', endVisit);
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/static/service-worker.js');
+}
+</script>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Login</title>
+<link rel="manifest" href="/static/manifest.json">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<style>
+body{font-family:system-ui,sans-serif;margin:0;background:#f9f9f9;display:flex;align-items:center;justify-content:center;height:100vh;}
+.card{max-width:400px;width:100%;padding:1rem;}
+input,button{width:100%;padding:0.75rem;font-size:1rem;margin-bottom:1rem;}
+</style>
+</head>
+<body>
+<div class="card">
+<form id="login-form">
+<input id="user_id" placeholder="Enter your ID" autocomplete="off" required>
+<button type="submit">Continue</button>
+</form>
+</div>
+<script>
+// Register service worker
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/static/service-worker.js');
+}
+document.getElementById('login-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const userId = document.getElementById('user_id').value.trim();
+  if (!userId) return;
+  localStorage.setItem('user_id', userId);
+  const res = await fetch('/api/login', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({ user_id: userId })
+  });
+  if (res.ok) {
+    window.location.href = '/content';
+  }
+});
+</script>
+</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "functions": {
+    "api/index.py": {
+      "runtime": "python3.11"
+    }
+  },
+  "routes": [
+    { "src": "^/api/.*", "dest": "/api/index.py" },
+    { "src": "/static/(.*)", "dest": "/static/$1" },
+    { "src": "/", "dest": "/api/index.py" }
+  ]
+}


### PR DESCRIPTION
## Summary
- build Flask app with login, visit tracking, and Supabase integration
- add mobile-friendly templates, PWA manifest, service worker, and icons
- include SQL schema, Vercel configuration, and documentation
- remove binary icon files and update manifest, service worker, and templates

## Testing
- `python -m py_compile api/index.py`


------
https://chatgpt.com/codex/tasks/task_e_68c54156e32083259e03310fdf6d0555