### PR TITLE
Add global stylesheet and polish mobile templates

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,66 @@
+:root {
+  --bg-color: #e6f7ff;
+  --bg-gradient-end: #fff5f7;
+  --primary-color: #4a90e2;
+  --card-bg: #ffffff;
+  --text-color: #333333;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+  margin: 0;
+  background: linear-gradient(135deg, var(--bg-color) 0%, var(--bg-gradient-end) 100%);
+  color: var(--text-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 16px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+  padding: 2rem;
+  box-sizing: border-box;
+  text-align: center;
+}
+
+h1 {
+  font-size: 1.5rem;
+  margin: 0 0 1rem;
+}
+
+p {
+  margin-bottom: 1rem;
+}
+
+input,
+button {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+}
+
+input:focus,
+button:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--primary-color);
+}
+
+button {
+  background: var(--primary-color);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}
+
+button:active {
+  opacity: 0.85;
+}

--- a/templates/content.html
+++ b/templates/content.html
@@ -6,15 +6,12 @@
 <title>Content</title>
 <link rel="manifest" href="/static/manifest.json">
 <meta name="apple-mobile-web-app-capable" content="yes">
-<style>
-body{font-family:system-ui,sans-serif;margin:0;background:#f9f9f9;display:flex;align-items:center;justify-content:center;height:100vh;}
-.card{max-width:400px;width:100%;padding:1rem;}
-</style>
+<link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>
 <div class="card">
-<p>User: {{ user_id }}</p>
-<p>Welcome!</p>
+  <h1>Hello, {{ user_id }}</h1>
+  <p>Welcome!</p>
 </div>
 <script>
 const userId = localStorage.getItem('user_id');

--- a/templates/login.html
+++ b/templates/login.html
@@ -6,18 +6,16 @@
 <title>Login</title>
 <link rel="manifest" href="/static/manifest.json">
 <meta name="apple-mobile-web-app-capable" content="yes">
-<style>
-body{font-family:system-ui,sans-serif;margin:0;background:#f9f9f9;display:flex;align-items:center;justify-content:center;height:100vh;}
-.card{max-width:400px;width:100%;padding:1rem;}
-input,button{width:100%;padding:0.75rem;font-size:1rem;margin-bottom:1rem;}
-</style>
+<link rel="stylesheet" href="/static/styles.css">
 </head>
 <body>
 <div class="card">
-<form id="login-form">
-<input id="user_id" placeholder="Enter your ID" autocomplete="off" required>
-<button type="submit">Continue</button>
-</form>
+  <h1>Welcome</h1>
+  <p>Please enter your ID to continue.</p>
+  <form id="login-form">
+    <input id="user_id" placeholder="Enter your ID" autocomplete="off" required>
+    <button type="submit">Continue</button>
+  </form>
 </div>
 <script>
 // Register service worker


### PR DESCRIPTION
## Summary
- Add global stylesheet with calming gradient, iOS-friendly fonts, and card layout
- Update login and content templates to use new styles and improved copy

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5b1824a04832597b9828304530d5c